### PR TITLE
Add Mixture-of-Experts Perceiver model

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,2 +1,3 @@
 from .target_cnn import TargetCNN
 from .perceiver_optimizer import PerceiverOptimizer
+from .perceiver_moe import MoELayer, PerceiverIO, PerceiverLM

--- a/models/perceiver_moe.py
+++ b/models/perceiver_moe.py
@@ -1,0 +1,282 @@
+from math import pi, log
+from functools import wraps
+
+import torch
+from torch import nn, einsum
+import torch.nn.functional as F
+
+from einops import rearrange, repeat
+
+class MoELayer(nn.Module):
+    def __init__(self, *, dim, num_experts, hidden_dim, k=2, dropout=0.0):
+        super().__init__()
+        self.k = k
+        self.experts = nn.ModuleList([nn.Sequential(nn.Linear(dim, hidden_dim), nn.GELU(), nn.Linear(hidden_dim, dim)) for _ in range(num_experts)])
+        self.gate = nn.Linear(dim, num_experts)
+        self.dropout = dropout
+
+    def forward(self, x):
+        gate_logits = self.gate(x)
+        if self.k < gate_logits.shape[-1]:
+            topk, indices = gate_logits.topk(self.k, dim=-1)
+            mask = torch.zeros_like(gate_logits).scatter_(-1, indices, 1.0)
+            gate_logits = gate_logits.masked_fill(mask == 0, float('-inf'))
+        gate = gate_logits.softmax(dim=-1)
+        expert_out = torch.stack([expert(x) for expert in self.experts], dim=-1)
+        out = einsum('... e, ... d e -> ... d', gate, expert_out)
+        return F.dropout(out, self.dropout, self.training)
+
+def exists(val):
+    return val is not None
+
+def default(val, d):
+    return val if exists(val) else d
+
+def cache_fn(f):
+    cache = None
+    @wraps(f)
+    def cached_fn(*args, _cache = True, **kwargs):
+        if not _cache:
+            return f(*args, **kwargs)
+        nonlocal cache
+        if cache is not None:
+            return cache
+        cache = f(*args, **kwargs)
+        return cache
+    return cached_fn
+
+
+def dropout_seq(seq, mask, dropout):
+    b, n, *_, device = *seq.shape, seq.device
+    logits = torch.randn(b, n, device = device)
+
+    if exists(mask):
+        logits = logits.masked_fill(~mask, -torch.finfo(logits.dtype).max)
+
+    keep_prob = 1. - dropout
+    num_keep = max(1,  int(keep_prob * n))
+    keep_indices = logits.topk(num_keep, dim = 1).indices
+
+    batch_indices = torch.arange(b, device = device)
+    batch_indices = rearrange(batch_indices, 'b -> b 1')
+
+    seq = seq[batch_indices, keep_indices]
+
+    if exists(mask):
+        seq_counts = mask.sum(dim = -1)
+        seq_keep_counts = torch.ceil(seq_counts * keep_prob).int()
+        keep_mask = torch.arange(num_keep, device = device) < rearrange(seq_keep_counts, 'b -> b 1')
+
+        mask = mask[batch_indices, keep_indices] & keep_mask
+
+    return seq, mask
+
+
+class PreNorm(nn.Module):
+    def __init__(self, dim, fn, context_dim = None):
+        super().__init__()
+        self.fn = fn
+        self.norm = nn.LayerNorm(dim)
+        self.norm_context = nn.LayerNorm(context_dim) if exists(context_dim) else None
+
+    def forward(self, x, **kwargs):
+        x = self.norm(x)
+
+        if exists(self.norm_context):
+            context = kwargs['context']
+            normed_context = self.norm_context(context)
+            kwargs.update(context = normed_context)
+
+        return self.fn(x, **kwargs)
+
+class GEGLU(nn.Module):
+    def forward(self, x):
+        x, gates = x.chunk(2, dim = -1)
+        return x * F.gelu(gates)
+
+class FeedForward(nn.Module):
+    def __init__(self, dim, mult = 4):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(dim, dim * mult * 2),
+            GEGLU(),
+            nn.Linear(dim * mult, dim)
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+class Attention(nn.Module):
+    def __init__(self, query_dim, context_dim = None, heads = 8, dim_head = 64):
+        super().__init__()
+        inner_dim = dim_head * heads
+        context_dim = default(context_dim, query_dim)
+        self.scale = dim_head ** -0.5
+        self.heads = heads
+
+        self.to_q = nn.Linear(query_dim, inner_dim, bias = False)
+        self.to_kv = nn.Linear(context_dim, inner_dim * 2, bias = False)
+        self.to_out = nn.Linear(inner_dim, query_dim)
+
+    def forward(self, x, context = None, mask = None):
+        h = self.heads
+
+        q = self.to_q(x)
+        context = default(context, x)
+        k, v = self.to_kv(context).chunk(2, dim = -1)
+
+        q, k, v = map(lambda t: rearrange(t, 'b n (h d) -> (b h) n d', h = h), (q, k, v))
+
+        sim = einsum('b i d, b j d -> b i j', q, k) * self.scale
+
+        if exists(mask):
+            mask = rearrange(mask, 'b ... -> b (...)')
+            max_neg_value = -torch.finfo(sim.dtype).max
+            mask = repeat(mask, 'b j -> (b h) () j', h = h)
+            sim.masked_fill_(~mask, max_neg_value)
+
+        attn = sim.softmax(dim = -1)
+
+        out = einsum('b i j, b j d -> b i d', attn, v)
+        out = rearrange(out, '(b h) n d -> b n (h d)', h = h)
+        return self.to_out(out)
+
+
+class PerceiverIO(nn.Module):
+    def __init__(
+        self,
+        *,
+        depth,
+        dim,
+        queries_dim,
+        logits_dim = None,
+        num_latents = 512,
+        latent_dim = 512,
+        cross_heads = 1,
+        latent_heads = 8,
+        cross_dim_head = 64,
+        latent_dim_head = 64,
+        weight_tie_layers = False,
+        decoder_ff = False,
+        seq_dropout_prob = 0.,
+        ff_dropout = 0.,
+        **kwargs
+    ):
+        super().__init__()
+        self.seq_dropout_prob = seq_dropout_prob
+
+        self.latents = nn.Parameter(torch.randn(num_latents, latent_dim))
+
+        self.cross_attend_blocks = nn.ModuleList([
+            PreNorm(latent_dim, Attention(latent_dim, dim, heads = cross_heads, dim_head = cross_dim_head), context_dim = dim),
+            PreNorm(latent_dim, FeedForward(latent_dim))
+        ])
+
+        get_latent_attn = lambda: PreNorm(latent_dim, Attention(latent_dim, heads = latent_heads, dim_head = latent_dim_head))
+        get_latent_ff = lambda: PreNorm(latent_dim, MoELayer(dim=latent_dim, num_experts=default(kwargs.get('moe_num_experts'), 8), hidden_dim=latent_dim * 4, k=default(kwargs.get('moe_k'), 2), dropout=ff_dropout))
+        get_latent_attn, get_latent_ff = map(cache_fn, (get_latent_attn, get_latent_ff))
+
+        self.layers = nn.ModuleList([])
+        cache_args = {'_cache': weight_tie_layers}
+
+        for i in range(depth):
+            self.layers.append(nn.ModuleList([
+                get_latent_attn(**cache_args),
+                get_latent_ff(**cache_args)
+            ]))
+
+        self.decoder_cross_attn = PreNorm(queries_dim, Attention(queries_dim, latent_dim, heads = cross_heads, dim_head = cross_dim_head), context_dim = latent_dim)
+        self.decoder_ff = PreNorm(queries_dim, FeedForward(queries_dim)) if decoder_ff else None
+
+        self.to_logits = nn.Linear(queries_dim, logits_dim) if exists(logits_dim) else nn.Identity()
+
+    def forward(
+        self,
+        data,
+        mask = None,
+        queries = None
+    ):
+        b, *_, device = *data.shape, data.device
+
+        x = repeat(self.latents, 'n d -> b n d', b = b)
+
+        cross_attn, cross_ff = self.cross_attend_blocks
+
+
+        if self.training and self.seq_dropout_prob > 0.:
+            data, mask = dropout_seq(data, mask, self.seq_dropout_prob)
+
+
+        x = cross_attn(x, context = data, mask = mask) + x
+        x = cross_ff(x) + x
+
+
+        for self_attn, self_ff in self.layers:
+            x = self_attn(x) + x
+            x = self_ff(x) + x
+
+        if not exists(queries):
+            return x
+
+
+        if queries.ndim == 2:
+            queries = repeat(queries, 'n d -> b n d', b = b)
+
+        
+        latents = self.decoder_cross_attn(queries, context = x)
+
+
+        if exists(self.decoder_ff):
+            latents = latents + self.decoder_ff(latents)
+
+
+        return self.to_logits(latents)
+
+
+class PerceiverLM(nn.Module):
+    def __init__(
+        self,
+        *,
+        dim,
+        num_tokens,
+        max_seq_len,
+        **kwargs
+    ):
+        super().__init__()
+        self.token_emb = nn.Embedding(num_tokens, dim)
+        self.pos_emb = nn.Embedding(max_seq_len, dim)
+
+        self.perceiver_io = PerceiverIO(
+            dim = dim,
+            queries_dim = dim,
+            logits_dim = num_tokens,
+            **kwargs
+        )
+
+    def forward(
+        self,
+        x,
+        mask = None
+    ):
+        n, device = x.shape[1], x.device
+        x = self.token_emb(x)
+
+        pos_emb = self.pos_emb(torch.arange(n, device = device))
+        pos_emb = rearrange(pos_emb, 'n d -> () n d')
+        x = x + pos_emb
+
+        logits = self.perceiver_io(x, mask = mask, queries = x)
+        return logits
+# KEY
+# - MoELayer: mixture-of-experts feed-forward module with top-k gating
+# - exists: function checking non-null
+# - default: return value or fallback
+# - cache_fn: wrapper returning cached function
+# - dropout_seq: structured dropout for sequences
+# - PreNorm: layer normalization before function
+# - GEGLU: gated linear unit activation
+# - FeedForward: two-layer feed-forward network
+# - Attention: multi-head attention
+# - PerceiverIO: perceiver encoder-decoder
+# - PerceiverLM: transformer language model example
+


### PR DESCRIPTION
## Summary
- implement `MoELayer` and new `PerceiverIO` using mixture-of-experts
- expose the new modules via `models.__init__`

## Testing
- `python -m py_compile models/perceiver_moe.py`
- `python -m py_compile models/perceiver_optimizer.py`

------
https://chatgpt.com/codex/tasks/task_e_688cce6042d48321a732eab65311bd76