### PR TITLE
Adjust target CNN size for CPU-friendly diffusion training

### DIFF
--- a/evaluate_generalization.py
+++ b/evaluate_generalization.py
@@ -240,6 +240,6 @@ if __name__ == '__main__':
         evaluate_diffusion_generated_checkpoints(
             diffusion_model_path=DIFFUSION_MODEL_LOAD_PATH,
             target_cnn_reference=reference_cnn_instance,
-            checkpoints_dir_original_cnn=checkpoints_DIR,
+            checkpoints_dir_original_cnn=CNN_checkpoints_DIR,
             plot_results=True # Set to False if you don't have matplotlib or a display
         )

--- a/models/target_cnn.py
+++ b/models/target_cnn.py
@@ -5,19 +5,15 @@ import torch.nn.functional as F
 class TargetCNN(nn.Module):
     def __init__(self):
         super(TargetCNN, self).__init__()
-        # For MNIST (28x28 grayscale images)
-        # Input channels = 1, output classes = 10
-        self.conv1 = nn.Conv2d(1, 32, kernel_size=3, stride=1, padding=1) # Output: 32x28x28
-        self.pool1 = nn.MaxPool2d(kernel_size=2, stride=2) # Output: 32x14x14
-        self.conv2 = nn.Conv2d(32, 64, kernel_size=3, stride=1, padding=1) # Output: 64x14x14
-        self.pool2 = nn.MaxPool2d(kernel_size=2, stride=2) # Output: 64x7x7
+        self.conv1 = nn.Conv2d(1, 4, kernel_size=3, stride=1, padding=1)
+        self.pool1 = nn.MaxPool2d(kernel_size=2, stride=2)
+        self.conv2 = nn.Conv2d(4, 8, kernel_size=3, stride=1, padding=1)
+        self.pool2 = nn.MaxPool2d(kernel_size=2, stride=2)
 
-        # Calculate the flattened size after conv and pool layers
-        # 64 channels * 7 height * 7 width
-        self.flattened_size = 64 * 7 * 7
+        self.flattened_size = 8 * 7 * 7
 
-        self.fc1 = nn.Linear(self.flattened_size, 128)
-        self.fc2 = nn.Linear(128, 10) # 10 classes for MNIST
+        self.fc1 = nn.Linear(self.flattened_size, 32)
+        self.fc2 = nn.Linear(32, 10)
 
     def forward(self, x):
         x = self.pool1(F.relu(self.conv1(x)))

--- a/train_diffusion.py
+++ b/train_diffusion.py
@@ -28,6 +28,7 @@ class WeightcheckpointsDataset(Dataset):
         self.checkpoints_dir = checkpoints_dir
         self.reference_state_dict = reference_state_dict
         self.flat_dim = get_target_model_flat_dim(reference_state_dict)
+        self.map_location = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
         weight_files = sorted(
             glob.glob(os.path.join(checkpoints_dir, "weights_epoch_*.pth")),
@@ -61,10 +62,10 @@ class WeightcheckpointsDataset(Dataset):
         w_path_next = self.weight_files[idx+1]
 
         try:
-            state_dict_current = torch.load(w_path_current, map_location='cuda')
+            state_dict_current = torch.load(w_path_current, map_location=self.map_location)
             current_w = flatten_state_dict(state_dict_current)
 
-            state_dict_next = torch.load(w_path_next, map_location='cuda')
+            state_dict_next = torch.load(w_path_next, map_location=self.map_location)
             target_next_w = flatten_state_dict(state_dict_next)
 
             if current_w.shape[0] != self.flat_dim or target_next_w.shape[0] != self.flat_dim:


### PR DESCRIPTION
## Summary
- shrink the TargetCNN architecture so the flattened weight dimension is small enough for the perceiver-based diffusion optimizer
- ensure the diffusion training dataset loads checkpoints on the active device, avoiding CUDA-only deserialization on CPU runs
- fix the generalization evaluation script to reference the configured CNN checkpoint directory

## Testing
- `PYTHONPATH=./models python -c "from train_target_model import train_target_cnn; train_target_cnn(epochs=10, save_interval_epochs=1, checkpoints_dir='checkpoints_weights_cnn')"`
- `PYTHONPATH=./models python train_diffusion.py`
- `PYTHONPATH=./models python evaluate_generalization.py`

------
https://chatgpt.com/codex/tasks/task_e_68ca03365a7c83259cd3b4d547df16f2